### PR TITLE
Fix: Clear game session on home page to prevent unwanted redirects

### DIFF
--- a/frontend/src/context/GameContext.jsx
+++ b/frontend/src/context/GameContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import socket from '../utils/socket';
-import { saveGameData, saveGuesses, saveGameState, getGameData, getGuesses, getGameState } from '../utils/localStorage';
+import { saveGameData, saveGuesses, saveGameState, getGameData, getGuesses, getGameState, clearAllGameData } from '../utils/localStorage';
 
 // Create the context
 const GameContext = createContext();
@@ -323,6 +323,22 @@ export const GameProvider = ({ children }) => {
     setError(null);
   }, []);
 
+  // Clear active game session
+  const clearActiveGameSession = useCallback(() => {
+    setGameId('');
+    setPlayerId('');
+    setPlayerName('');
+    setGameState('initial');
+    setIsHost(false);
+    setPlayers([]);
+    setGuesses([]);
+    setTargetCountry(null);
+    setWinner(null);
+    setError(null);
+    setIsLoading(false);
+    clearAllGameData();
+  }, []);
+
   // Context value
   const value = {
     // State
@@ -345,6 +361,7 @@ export const GameProvider = ({ children }) => {
     makeGuess,
     leaveGame,
     clearError,
+    clearActiveGameSession,
   };
 
   return (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,11 +4,16 @@ import { useNavigate } from 'react-router-dom';
 import { useGame } from '../context/GameContext';
 
 const Home = () => {
-  const { createGame, joinGame, isLoading, error, clearError, gameId: activeGameId } = useGame();
+  const { createGame, joinGame, isLoading, error, clearError, gameId: activeGameId, clearActiveGameSession } = useGame();
   const navigate = useNavigate();
   const [name, setName] = useState('');
   const [gameId, setGameId] = useState('');
   const [view, setView] = useState('main'); // main, create, join
+
+  // Effect to clear any active game session when returning to Home
+  useEffect(() => {
+    clearActiveGameSession();
+  }, []); // Ensure this runs only once on mount
 
   // Effect to navigate to game page when game ID is available
   useEffect(() => {


### PR DESCRIPTION
This commit addresses an issue where you were being unintentionally redirected to a previous game when navigating to the home page. This was due to lingering game data in localStorage and the GameContext.

The following changes were made:
1.  A new function `clearActiveGameSession` was added to `GameContext.jsx`. This function resets all game-related state variables in the context and calls `clearAllGameData()` from `localStorage.js` to remove all game-related items from localStorage.
2.  In `Home.jsx`, a `useEffect` hook was added that runs once on component mount. This hook calls `clearActiveGameSession()` to ensure that any prior game session is definitively cleared whenever you land on the Home page.

These changes ensure that navigating to the home page provides a clean slate, allowing you to start new games or join existing ones without being affected by previous sessions.