### PR TITLE
Fix: Ensure homepage content is visible on initial load

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -36,13 +36,13 @@ const Home = () => {
   };
 
   const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: { opacity: 1, transition: { staggerChildren: 0.1, delayChildren: 0.2 } },
+    hidden: { opacity: 1 },
+    visible: { opacity: 1, transition: { staggerChildren: 0.1, delayChildren: 0 } },
     exit: { opacity: 0, transition: { duration: 0.3 } }
   };
 
   const itemVariants = {
-    hidden: { y: 30, opacity: 0 },
+    hidden: { y: 0, opacity: 1 },
     visible: { y: 0, opacity: 1, transition: { type: 'spring', stiffness: 100, duration: 0.5 } }
   };
 
@@ -52,7 +52,7 @@ const Home = () => {
   };
 
   const cardVariants = {
-    hidden: { opacity: 0, scale: 0.95 },
+    hidden: { opacity: 1, scale: 1 },
     visible: { opacity: 1, scale: 1, transition: { duration: 0.4, ease: "easeOut" } }
   };
 
@@ -287,9 +287,9 @@ const Home = () => {
       {/* Footer */}
       <motion.footer 
         className="py-6 px-4 sm:px-8 text-center bg-slate-800 text-slate-300 mt-12"
-        initial={{ opacity: 0 }}
+        initial={{ opacity: 1 }}
         animate={{ opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.5 }}
+        transition={{ duration: 0.5 }}
       >
         <div className="container mx-auto">
           <p className="mb-2 text-lg">


### PR DESCRIPTION
I removed entry animations that caused homepage content to be initially hidden (e.g., opacity 0 or delayed). This change is intended to improve accessibility for web crawlers, including AdSense, which might perceive the page as unavailable if content is not immediately visible.

Modifications in `frontend/src/pages/Home.jsx`:
- I adjusted Framer Motion variants (`containerVariants`, `itemVariants`, `cardVariants`) to have `opacity: 1` and appropriate visible transformations in their `initial` state.
- I removed or set to zero any `delayChildren` or specific `delay` properties in transitions that would postpone the appearance of content for these variants.
- I ensured the footer also renders with `opacity: 1` initially without delay.

This should allow crawlers to access page content immediately upon rendering.